### PR TITLE
Ignore inner class

### DIFF
--- a/patterns/detect/dont_catch_illegal_monitor_state_exception.py
+++ b/patterns/detect/dont_catch_illegal_monitor_state_exception.py
@@ -18,7 +18,7 @@ class DontCatchIllegalMonitorStateException(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        match = self.p_catch.search(linecontent)
+        match = self.p_catch.search(linecontent.strip())
 
         if match:
             params = match.groups()[0]

--- a/patterns/detect/dumb_methods.py
+++ b/patterns/detect/dumb_methods.py
@@ -11,7 +11,7 @@ class FinalizerOnExitDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             pkg_name = m.groups()[0]
             confidence = Priorities.HIGH_PRIORITY
@@ -30,7 +30,7 @@ class RandomOnceDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             self.bug_accumulator.append(
                 BugInstance('DMI_RANDOM_USED_ONLY_ONCE', Priorities.HIGH_PRIORITY, filename, lineno,
@@ -44,7 +44,7 @@ class RandomD2IDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             obj = m.groups()[0].strip().lower()
             if obj == 'math' or obj == 'r' or 'rand' in obj:
@@ -60,7 +60,7 @@ class StringCtorDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             groups = m.groups()
             assert len(groups) == 2

--- a/patterns/detect/find_finalize_invocations.py
+++ b/patterns/detect/find_finalize_invocations.py
@@ -11,7 +11,7 @@ class ExplicitInvDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m and m.groups()[0] != 'super':
             self.bug_accumulator.append(
                 BugInstance('FI_EXPLICIT_INVOCATION', Priorities.HIGH_PRIORITY, filename, lineno,
@@ -25,7 +25,7 @@ class PublicAccessDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             self.bug_accumulator.append(
                 BugInstance('FI_PUBLIC_SHOULD_BE_PROTECTED', Priorities.MEDIUM_PRIORITY, filename, lineno,

--- a/patterns/detect/find_ref_comparison.py
+++ b/patterns/detect/find_ref_comparison.py
@@ -26,7 +26,7 @@ class EqualityDetector(Detector):
         if not any(op in linecontent for op in ['==', '!=']):
             return
 
-        m = self.p.search(linecontent)
+        m = self.p.search(linecontent.strip())
         if m:
             op_1 = m.groups()[0]  # m.groups()[1] is the result of named pattern
             op_2 = m.groups()[2]
@@ -61,7 +61,7 @@ class CalToNullDetector(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.p.search(linecontent)
+        m = self.p.search(linecontent.strip())
         if m:
             self.bug_accumulator.append(
                 BugInstance('EC_NULL_ARG', Priorities.MEDIUM_PRIORITY,

--- a/patterns/detect/find_unrelated_types_in_generic_container.py
+++ b/patterns/detect/find_unrelated_types_in_generic_container.py
@@ -15,7 +15,7 @@ class SuspiciousCollectionMethodDetector(Detector):
         if not any(method in linecontent for method in ['remove', 'contains', 'retain']):
             return
 
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
 
         if m:
             g = m.groups()

--- a/patterns/detect/format_string_checker.py
+++ b/patterns/detect/format_string_checker.py
@@ -11,7 +11,7 @@ class NewLineDetector(Detector):
         self.p = re.compile(r'(?:(?:String\.format)|printf)\([\w.\s()]*,?\s*"([^"]*)"\s*')
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.p.search(linecontent)
+        m = self.p.search(linecontent.strip())
         if m:
             format_str = m.groups()[0]
 

--- a/patterns/detect/incompat_mask.py
+++ b/patterns/detect/incompat_mask.py
@@ -49,7 +49,7 @@ class IncompatMaskDetector(Detector):
         if '&' not in linecontent and not any(op in linecontent for op in ('>', '<', '>=', '<=', '==', '!=')):
             return
 
-        m = self.regexpSign.search(linecontent)
+        m = self.regexpSign.search(linecontent.strip())
         if m:
             g = m.groups()
             operand_1 = g[0]

--- a/patterns/detect/infinite_recursive_loop.py
+++ b/patterns/detect/infinite_recursive_loop.py
@@ -13,7 +13,7 @@ class CollectionAddItselfDetector(Detector):
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
         if "add" not in linecontent:
             return
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             self.bug_accumulator.append(
                 BugInstance('IL_CONTAINER_ADDED_TO_ITSELF', Priorities.HIGH_PRIORITY, filename,

--- a/patterns/detect/inheritance_unsafe_get_resource.py
+++ b/patterns/detect/inheritance_unsafe_get_resource.py
@@ -14,7 +14,7 @@ class GetResourceDetector(Detector):
         if not all(method in linecontent for method in ['getClass', 'getResource']):
             return
 
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             obj_name = m.groups()[0]
             if not obj_name or obj_name == 'this':

--- a/patterns/detect/method_return_check.py
+++ b/patterns/detect/method_return_check.py
@@ -11,7 +11,7 @@ class NotThrowDetector(Detector):
         self.pattern = regex.compile(r'^\s*new\s+(\w+?)(?:Exception|Error)\s*\(')
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             self.bug_accumulator.append(
                 BugInstance('RV_EXCEPTION_NOT_THROWN', Priorities.MEDIUM_PRIORITY,

--- a/patterns/detect/naming.py
+++ b/patterns/detect/naming.py
@@ -17,17 +17,18 @@ class SimpleNameDetector1(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             g = m.groups()
             class_name = clearName(g[0])
             super_class_name = clearName(g[2])
 
             if class_name == super_class_name:
-                self.bug_accumulator.append(
-                    BugInstance('NM_SAME_SIMPLE_NAME_AS_SUPERCLASS', Priorities.HIGH_PRIORITY, filename, lineno,
-                                "Class names shouldn’t shadow simple name of superclass")
-                )
+                if len(linecontent) == len(linecontent.lstrip()):
+                    self.bug_accumulator.append(
+                        BugInstance('NM_SAME_SIMPLE_NAME_AS_SUPERCLASS', Priorities.HIGH_PRIORITY, filename, lineno,
+                                    "Class names shouldn’t shadow simple name of superclass")
+                    )
 
 
 class SimpleNameDetector2(Detector):
@@ -38,9 +39,9 @@ class SimpleNameDetector2(Detector):
         Detector.__init__(self)
 
     def match(self, linecontent: str, filename: str, lineno: int, get_exact_lineno=None):
-        m = self.pattern1.search(linecontent)
+        m = self.pattern1.search(linecontent.strip())
         if not m:
-            m = self.pattern2.search(linecontent)
+            m = self.pattern2.search(linecontent.strip())
 
         if m:
             g = m.groups()
@@ -50,7 +51,8 @@ class SimpleNameDetector2(Detector):
                 interface_names.append(clearName(itf))
 
             if class_name in interface_names:
-                self.bug_accumulator.append(
-                    BugInstance('NM_SAME_SIMPLE_NAME_AS_INTERFACE', Priorities.MEDIUM_PRIORITY, filename, lineno,
-                                "Class or interface names shouldn’t shadow simple name of implemented interface")
-                )
+                if len(linecontent) == len(linecontent.lstrip()):
+                    self.bug_accumulator.append(
+                        BugInstance('NM_SAME_SIMPLE_NAME_AS_INTERFACE', Priorities.MEDIUM_PRIORITY, filename, lineno,
+                                    "Class or interface names shouldn’t shadow simple name of implemented interface")
+                    )

--- a/patterns/detect/serializable_idiom.py
+++ b/patterns/detect/serializable_idiom.py
@@ -14,7 +14,7 @@ class DefSerialVersionID(Detector):
         if 'serialVersionUID' not in linecontent:
             return
 
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             g = m.groups()
             prefix = None
@@ -55,7 +55,7 @@ class DefReadResolveMethod(Detector):
         if any(const not in linecontent for const in ['readResolve', 'throws', 'ObjectStreamException']):
             return
 
-        m = self.pattern.search(linecontent)
+        m = self.pattern.search(linecontent.strip())
         if m:
             g = m.groups()
 

--- a/patterns/detect/static_calendar_detector.py
+++ b/patterns/detect/static_calendar_detector.py
@@ -15,7 +15,7 @@ class StaticDateFormatDetector(Detector):
         if not any(key in linecontent for key in ('DateFormat', 'Calendar')):
             return
 
-        m = self.p.search(linecontent)
+        m = self.p.search(linecontent.strip())
 
         if m:
             groups = m.groups()

--- a/patterns/detectors.py
+++ b/patterns/detectors.py
@@ -54,23 +54,6 @@ class DefaultEngine(BaseEngine):
                     continue
 
                 line_content = hunk.lines[i].content
-                if i in hunk.addlines:
-                    line_content = line_content[1:]  # remove "+"
-
-                line_content = line_content.strip()
-                if not line_content or line_content.startswith('//'):
-                    continue
-
-                # skip multiline comments
-                if line_content.startswith('/*'):
-                    if not line_content.endswith('*/'):
-                        in_multiline_comments = True
-                    continue
-
-                if in_multiline_comments:
-                    if line_content.endswith('*/'):
-                        in_multiline_comments = False
-                    continue
 
                 for detector in self.detectors:
                     method = None

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -8,44 +8,52 @@ params = [
     # From other repository: https://github.com/tesshucom/jpsonic/commit/04425589726efad5532e5828326f2de38e643cb1
     (True, 'NM_SAME_SIMPLE_NAME_AS_SUPERCLASS', 'AirsonicSpringLiquibase.java',
      '''@@ -15,8 +15,9 @@
-        import java.sql.Connection;
-        import java.util.List;
+import java.sql.Connection;
+import java.util.List;
 
-        public class SpringLiquibase extends liquibase.integration.spring.SpringLiquibase''', 1, 18),
+public class SpringLiquibase extends liquibase.integration.spring.SpringLiquibase''', 1, 18),
     # DIY from: https://github.com/makotoarakaki/aipo/commit/b4eae261c527a41af1ade5b1d1fa95548f9a36cc
     (True, 'NM_SAME_SIMPLE_NAME_AS_SUPERCLASS', 'ALActivityImpl.java',
      '''@@ -29,8 +29,9 @@
-    public class ALActivityImpl extends org.apache.shindig.social.core.model.ALActivityImpl implements Activity {''', 1, 29),
+public class ALActivityImpl extends org.apache.shindig.social.core.model.ALActivityImpl implements Activity {''', 1, 29),
     # From other repository: https://github.com/tesshucom/jpsonic/commit/e82450ff9e8cd81ac0122de9f268f36c68683464
     (True, 'NM_SAME_SIMPLE_NAME_AS_INTERFACE', 'AirsonicLocaleResolver.java',
      '''@@ -39,7 +39,7 @@
-         * @author Sindre Mehus
-         */
-        @Service
-        public class LocaleResolver implements org.springframework.web.servlet.LocaleResolver {
-        + public class AirsonicLocaleResolver implements org.springframework.web.servlet.LocaleResolver {''', 1, 42),
+* @author Sindre Mehus
+*/
+@Service
+public class LocaleResolver implements org.springframework.web.servlet.LocaleResolver {
++public class AirsonicLocaleResolver implements org.springframework.web.servlet.LocaleResolver {''', 1, 42),
     # From other repository: https://github.com/hashbase/hashbase/commit/c47511baa7a8e50cecc9296f685b49249174cc77
     (True, 'NM_SAME_SIMPLE_NAME_AS_INTERFACE', 'Future.java',
      '''@@ -26,6 +26,9 @@
-         */
-        @InterfaceAudience.Public
-        @InterfaceStability.Evolving
-        public interface Future<V> extends io.netty.util.concurrent.Future<V> {''', 1, 29),
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface Future<V> extends io.netty.util.concurrent.Future<V> {''', 1, 29),
     # DIY
     (True, 'NM_SAME_SIMPLE_NAME_AS_INTERFACE', 'AirsonicLocaleResolver.java',
      '''@@ -39,7 +39,7 @@
-     * @author Sindre Mehus
-     */
-    @Service
-    public class LocaleResolver extends DIYClass implements DIYInterface, org.springframework.web.servlet.LocaleResolver {''',
+* @author Sindre Mehus
+*/
+@Service
+public class LocaleResolver extends DIYClass implements DIYInterface, org.springframework.web.servlet.LocaleResolver {''',
      1, 42),
     # DIY
     (True, 'NM_SAME_SIMPLE_NAME_AS_INTERFACE', 'Future.java',
      '''@@ -26,6 +26,9 @@
-         */
-        @InterfaceAudience.Public
-        @InterfaceStability.Evolving
-        public interface Future<V> extends DIYInterface, io.netty.util.concurrent.Future<V> {''', 1, 29),
+*/
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface Future<V> extends DIYInterface, io.netty.util.concurrent.Future<V> {''', 1, 29),
+    # From other repository: https://github.com/elastic/elasticsearch/blob/master/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java#L188
+    (False, 'NM_SAME_SIMPLE_NAME_AS_SUPERCLASS', 'ICUCollationKeywordFieldMapper.java',
+     '''public class ICUCollationKeywordFieldMapper extends FieldMapper {
+    public static final String CONTENT_TYPE = "icu_collation_keyword";
+    
+    public static class Builder extends FieldMapper.Builder {
+        final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
+        final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);''', 0, 4),
 ]
 
 


### PR DESCRIPTION
Close #61 

1. Fix bug in DefaultEngine. The Line#content doesn't contain prefix '+' or '-' any longer since refactor #44 
2. Ignore inner class by the leading spaces of `linecontent`