### PR TITLE
Self computation: check method call

### DIFF
--- a/patterns/detect/find_self_comparison.py
+++ b/patterns/detect/find_self_comparison.py
@@ -39,8 +39,12 @@ class CheckForSelfComputation(Detector):
             op = g[2]
             op_offset = m.start(3)
             obj_2 = g[3]
-            if obj_1 == obj_2 and not obj_1.endswith(')') and op in ('&', '|', '^', '-') and\
+            if obj_1 == obj_2 and op in ('&', '|', '^', '-') and\
                     not in_range(op_offset, string_ranges):
+                # to filter method called on Random object
+                if any(k in obj_1 for k in ('random', 'Random', 'next')):
+                    continue
+
                 pre_substring = line_content[:m.start(0)].rstrip()
                 op_front = None
                 if pre_substring[-2:] in self._op_precedence_dict:

--- a/tests/test_find_self_comparison.py
+++ b/tests/test_find_self_comparison.py
@@ -49,7 +49,9 @@ params = [
     (False, 'SA_SELF_COMPUTATION', 'DIY_08.java',
      'return i | j & j | z;', 0, 0),
     (False, 'SA_SELF_COMPUTATION', 'DIY_09.java',
-     'double second = requestMetrics.endDate.getTime() - requestMetrics.endDate.getTime();', 0, 0),
+     'double second = requestMetrics.endDate.getTime() - requestMetrics.endDate.getTime();', 1, 1),
+    (False, 'SA_SELF_COMPUTATION', 'DIY_10.java',
+     'player.world.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((player.getRandom().nextFloat() - player.getRandom().nextFloat()) * 0.7F + 1.0F) * 2.0F);', 0, 0),
     # ---------------- SA_SELF_COMPARISON ----------------------
     (False, 'SA_SELF_COMPARISON', 'SelfFieldOperation_02.java',
      '''@NoWarning("SA_FIELD_SELF_COMPARISON")


### PR DESCRIPTION
From fc6d0df21baaab377f50006262dab430f2dcb0b2, self computation detector does not check method call any more. But it's just one of the differences between us and spotbugs. Therefore, we decide to support method call again, and just filter possible method call related to a random object.

The following example is found at #154
```java
double second = requestMetrics.endDate.getTime() - requestMetrics.endDate.getTime();
```